### PR TITLE
 Standardize simple and double quote characters

### DIFF
--- a/Securescore/Secure Score Demo API.ps1
+++ b/Securescore/Secure Score Demo API.ps1
@@ -2,11 +2,11 @@ $cred = Get-Credential
 $mycred = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential($cred.UserName,$cred.Password)
 
 # Defining Azure AD tenant name, this is the name of your Azure Active Directory, where xxxxxxxxxxxxxxxxxxx is the ID of your O365 Tenant
-$adTenant = "xxxxxxxxxxxxxxxxxxxxxxxxxx.onmicrosoft.com”
+$adTenant = "xxxxxxxxxxxxxxxxxxxxxxxxxx.onmicrosoft.com"
 
 # Load Active Directory Authentication Library (ADAL) Assemblies
-$adal = “${env:ProgramFiles(x86)}\Microsoft SDKs\Azure\PowerShell\ServiceManagement\Azure\Services\Microsoft.IdentityModel.Clients.ActiveDirectory.dll”
-$adalforms = “${env:ProgramFiles(x86)}\Microsoft SDKs\Azure\PowerShell\ServiceManagement\Azure\Services\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll”
+$adal = "${env:ProgramFiles(x86)}\Microsoft SDKs\Azure\PowerShell\ServiceManagement\Azure\Services\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
+$adalforms = "${env:ProgramFiles(x86)}\Microsoft SDKs\Azure\PowerShell\ServiceManagement\Azure\Services\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll"
 [System.Reflection.Assembly]::LoadFrom($adal)
 [System.Reflection.Assembly]::LoadFrom($adalforms)
 
@@ -14,16 +14,16 @@ $adalforms = “${env:ProgramFiles(x86)}\Microsoft SDKs\Azure\PowerShell\Service
 $clientId = "xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
 # Set redirect URI for Azure PowerShell
-$redirectUri = “urn:ietf:wg:oauth:2.0:oob”
+$redirectUri = "urn:ietf:wg:oauth:2.0:oob"
 
 # Set Resource URI to Azure Service Management API
-$resourceAppIdURI = “https://graph.microsoft.com/”
+$resourceAppIdURI = "https://graph.microsoft.com/"
 
 # Set Authority to Azure AD Tenant
-$authority = “https://login.windows.net/$adTenant“
+$authority = "https://login.windows.net/$adTenant"
 
 # Create AuthenticationContext tied to Azure AD Tenant
-$authContext = New-Object “Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext” -ArgumentList $authority
+$authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
 
 # Acquire token
 $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $mycred)
@@ -31,9 +31,9 @@ $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, $mycred)
 # Building Rest Api header with authorization token
 $authHeader = @{
 
-‘Content-Type’=‘application\json’
+'Content-Type'='application\json'
 
-‘Authorization’=$authResult.CreateAuthorizationHeader()
+'Authorization'=$authResult.CreateAuthorizationHeader()
 }
 
 # Execute the REST query, where X = the integer value of 1-90 of the number of days history you wish to retrieve.


### PR DESCRIPTION
“ => "
’ => '